### PR TITLE
As of PHP version 5.6.0 the option name SNI_server_name is deprecated…

### DIFF
--- a/libs/PHPCrawlerHTTPRequest.class.php
+++ b/libs/PHPCrawlerHTTPRequest.class.php
@@ -544,7 +544,12 @@ class PHPCrawlerHTTPRequest
       // If ssl -> perform Server name indication
       if ($this->url_parts["protocol"] == "https://")
       {
-        $context = stream_context_create(array('ssl' => array('SNI_server_name' => $this->url_parts["host"])));
+        if (version_compare(PHP_VERSION, '5.6.0') >= 0) {
+          $ssl_key='peer_name';
+        } else {
+          $ssl_key='SNI_server_name';
+        }
+        $context = stream_context_create(array('ssl' => array( $ssl_key => $this->url_parts["host"])));
         $this->socket = @stream_socket_client($protocol_prefix.$ip_address.":".$this->url_parts["port"], $error_code, $error_str,
                                               $this->socketConnectTimeout, STREAM_CLIENT_CONNECT, $context);
       }
@@ -911,7 +916,8 @@ class PHPCrawlerHTTPRequest
     
     $headerlines[] = "Host: ".$this->url_parts["host"]."\r\n";
     
-    $headerlines[] = "User-Agent: ".str_replace("\n", "", $this->userAgentString)."\r\n";    $headerlines[] = "Accept: */*\r\n";
+    $headerlines[] = "User-Agent: ".str_replace("\n", "", $this->userAgentString)."\r\n";
+    $headerlines[] = "Accept: */*\r\n";
     
     // Request GZIP-content
     if ($this->request_gzip_content == true)


### PR DESCRIPTION
…. The valid option is peer_name.

Without this change it won't be able to crawls secure sites.